### PR TITLE
TimescaleDB_dev_database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/home/postgres/pgdata
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
       interval: 20s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
 
       TIMESCALEDB_TELEMETRY: off
-      ALLOW_NOSSL: "true" # for local dev
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,19 @@
 services:
   db:
-    image: postgis/postgis:16-3.4
-    container_name: geodjango_postgis
+    image: timescale/timescaledb-ha:pg17-all
+    container_name: geodjango_postgis_timescale
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${DB_NAME}
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
+
+      TIMESCALEDB_TELEMETRY: off
+      ALLOW_NOSSL: "true" # for local dev
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/home/postgres/pgdata
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
       interval: 20s


### PR DESCRIPTION
This PR:
 - Pulls the Timescale DB docker image (with postgis extensions already installed) for our dev db
 - Adds a couple Timescale specific db settings to docker-compose
 
 - This should not change how the current models work. Specific Timescale hypertables  / models would need to be created via migrations to enable any Timescale-specific features.