### PR TITLE
Volume-path-correction

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/home/postgres/pgdata/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
       interval: 20s


### PR DESCRIPTION
This PR:
 - Updates the volume path in the timescale docker container to use the appropriate working directory for the timescaledb-ha docker image. Working directory documentation: https://hub.docker.com/layers/timescale/timescaledb-ha/pg-ts-all-oss/images/sha256-8cd380877994500fcd73920271996d23f35667a10d4b370a976ad13f07df52ce
 - This fixes an issues where data was not persisted between dev sessions.