### PR TITLE
Unfold-admin-panel-styling

### DIFF
--- a/geodjango/geodjango/settings.py
+++ b/geodjango/geodjango/settings.py
@@ -35,6 +35,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'unfold',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/geodjango/geodjango/settings.py
+++ b/geodjango/geodjango/settings.py
@@ -148,5 +148,8 @@ UNFOLD = {
             "900": "0, 44, 49",
             "950": "0, 28, 31",
         },
-    }
+    },
+    "SITE_TITLE": "NMBGMR",
+    "SITE_HEADER": "NMBGMR",
+    "SITE_SUBHEADER": "Data Management System",
 }

--- a/geodjango/geodjango/settings.py
+++ b/geodjango/geodjango/settings.py
@@ -132,3 +132,21 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+UNFOLD = {
+    "COLORS": {
+        "primary": {
+            "50":  "242, 248, 248",
+            "100": "230, 240, 242",
+            "200": "191, 219, 222",
+            "300": "153, 197, 202",
+            "400": "115, 175, 182",
+            "500": "0, 110, 123", 
+            "600": "0, 94, 105",
+            "700": "0, 77, 86",
+            "800": "0, 61, 68",
+            "900": "0, 44, 49",
+            "950": "0, 28, 31",
+        },
+    }
+}

--- a/geodjango/samplelocations/admin.py
+++ b/geodjango/samplelocations/admin.py
@@ -1,11 +1,35 @@
 from django.contrib import admin
+from unfold.admin import ModelAdmin 
 from .models import SampleLocation, Owner, Contact, Well, Lexicon, WellScreen, Equipment, Spring 
 
-admin.site.register(SampleLocation)
-admin.site.register(Owner)
-admin.site.register(Contact)
-admin.site.register(Lexicon)
-admin.site.register(Well)
-admin.site.register(WellScreen)
-admin.site.register(Equipment)
-admin.site.register(Spring)
+@admin.register(SampleLocation)
+class SampleLocationAdmin(ModelAdmin):
+    pass
+
+@admin.register(Owner)
+class OwnerAdmin(ModelAdmin):
+    pass
+
+@admin.register(Contact)
+class ContactAdmin(ModelAdmin):
+    pass
+
+@admin.register(Lexicon)
+class LexiconAdmin(ModelAdmin):
+    pass
+
+@admin.register(Well)
+class WellAdmin(ModelAdmin):
+    pass
+
+@admin.register(WellScreen)
+class WellScreenAdmin(ModelAdmin):
+    pass
+
+@admin.register(Equipment)
+class EquipmentAdmin(ModelAdmin):
+    pass
+
+@admin.register(Spring)
+class SpringAdmin(ModelAdmin):
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "django>=5.2.3",
     "django-ninja>=1.4.3",
+    "django-unfold>=0.61.0",
     "psycopg2-binary>=2.9.10",
     "python-dotenv>=1.1.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -48,12 +48,25 @@ wheels = [
 ]
 
 [[package]]
+name = "django-unfold"
+version = "0.61.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/c5/b4f0231b76ac363c84c0c006a37d3c7c86709e1ce7b2a05d3c28a6030931/django_unfold-0.61.0.tar.gz", hash = "sha256:97e6d68600f8c9fbf4e3cf64bcc81c93dd4627150541e0e077e72f112a3a31a2", size = 1064069, upload-time = "2025-06-30T13:30:45.228Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/58/38c0a0249e621b5477afbaa386ff2bb50d42cc3de5e439ea3104f1759754/django_unfold-0.61.0-py3-none-any.whl", hash = "sha256:c1314094b6cb003491d551b854012abea774f1e35d58b930a9d8d354172d21d0", size = 1170810, upload-time = "2025-06-30T13:30:43.975Z" },
+]
+
+[[package]]
 name = "geodjangopoc"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },
     { name = "django-ninja" },
+    { name = "django-unfold" },
     { name = "psycopg2-binary" },
     { name = "python-dotenv" },
 ]
@@ -62,6 +75,7 @@ dependencies = [
 requires-dist = [
     { name = "django", specifier = ">=5.2.3" },
     { name = "django-ninja", specifier = ">=1.4.3" },
+    { name = "django-unfold", specifier = ">=0.61.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
 ]


### PR DESCRIPTION
This PR:
 - Adds the Unfold admin panel styling that we looked at last week
 -- https://unfoldadmin.com/docs/
 - Updates the installed apps to include Unfold
 - Updates admin.py to use the unfold @admin.register syntax
 - Changes the primary colors to be the WDI deep cyan pallet.

 - This is a minimal Unfold setup - holding off on additional customization for now will allow us to easily remove it if we decide not to use Unfold.